### PR TITLE
Scaling down

### DIFF
--- a/manager/src/main.go
+++ b/manager/src/main.go
@@ -255,9 +255,9 @@ func main() {
 			queueProvider,
 			config.ExecutorQueueName,
 			executorDeployer,
-			0, // Scale down when we have no items in the queue
-			1, // Scale up when we have 1 or more items in the queue
-			1, // Minimum number of services
+			0,     // Scale down when we have no items in the queue
+			10000, // We do not want to scale up the executor
+			1,     // Minimum number of services
 			logger,
 		)
 		if err != nil {

--- a/manager/src/scaler/queue_watermark.go
+++ b/manager/src/scaler/queue_watermark.go
@@ -158,7 +158,7 @@ func (qwm *QueueWatermark) ScaleDown() error {
 		return err
 	}
 	proposedServiceCount := currentServiceCount - 1
-	if proposedServiceCount <= qwm.minimumServiceCount {
+	if proposedServiceCount < qwm.minimumServiceCount {
 		qwm.logger.WithFields(logrus.Fields{
 			"proposedServiceCount": proposedServiceCount,
 			"minimumServiceCount":  qwm.minimumServiceCount,


### PR DESCRIPTION
This PR contains two changes

1. Effectively prevent scaling the indexer by putting a very high count. We do not want to scale the indexer to prevent account sequence errors
2. Scale down when there are no items left in the queue at the start of the next block. There are some considerations for this, please see the comments in the PRx

Not overly happy with my current solution and welcome feedback