### PR TITLE
feat: generalised collector now supports both rover and redbank postions

### DIFF
--- a/health-checker/src/health-checker/health_checker_test.go
+++ b/health-checker/src/health-checker/health_checker_test.go
@@ -33,9 +33,7 @@ func initService() HealthChecker {
 func TestWeCanGenerateAndRunJobs(t *testing.T) {
 	batchSize := 200
 	mockPosition := types.HealthCheckWorkItem{
-		Address:    "osmo18nm43hck80s2et26g2csvltecvhk49526dugd9",
-		Debts:      []types.Asset{},
-		Collateral: []types.Asset{},
+		Identifier: "osmo18nm43hck80s2et26g2csvltecvhk49526dugd9",
 	}
 
 	positions := []types.HealthCheckWorkItem{}
@@ -85,11 +83,11 @@ func TestCanFilterUnhealthyPositions(t *testing.T) {
 	// create fake positions
 	results := []UserResult{
 		{
-			Address:       "aaaaaa",
+			Identifier:    "aaaaaa",
 			ContractQuery: dataA,
 		},
 		{
-			Address:       "bbbbbb",
+			Identifier:    "bbbbbb",
 			ContractQuery: dataB,
 		},
 	}

--- a/health-checker/src/health-checker/hive.go
+++ b/health-checker/src/health-checker/hive.go
@@ -50,10 +50,8 @@ type UserPosition struct {
 }
 
 type UserResult struct {
-	Address       string
+	Identifier    string
 	ContractQuery ContractQuery
-	Debts         []types.Asset
-	Collateral    []types.Asset
 }
 
 // BatchEventsResponse defines the format for batch position responses
@@ -72,16 +70,16 @@ func (hive *Hive) FetchBatch(
 	for _, position := range positions {
 
 		// store addresses in this local map so that we can easily add debts and collateral later
-		positonMap[position.Address] = position
+		positonMap[position.Identifier] = position
 		batchQuery := BatchQuery{
 			Query: fmt.Sprintf(`query($contractAddress: String! $userAddress: String!) {
                         %s:wasm {
 							contractQuery(contractAddress: $contractAddress, query: { user_position : { user: $userAddress } })
 						}
-                    }`, position.Address),
+                    }`, position.Identifier),
 			Variables: map[string]interface{}{
 				"contractAddress": contractAddress,
-				"userAddress":     position.Address,
+				"userAddress":     position.Identifier,
 			},
 		}
 		queries = append(queries, batchQuery)
@@ -112,79 +110,10 @@ func (hive *Hive) FetchBatch(
 	for _, event := range batchEvents {
 		// event.Data is now the address[contractQuery] map
 
-		for address, data := range event.Data {
-			position := positonMap[address]
+		for identifier, data := range event.Data {
 			userResults = append(userResults, UserResult{
-				Address:       address,
+				Identifier:    identifier,
 				ContractQuery: data.ContractQuery,
-				Debts:         position.Debts,
-				Collateral:    position.Collateral,
-			})
-		}
-	}
-
-	return userResults, nil
-}
-
-func (hive *Hive) FetchRoverBatch(
-	contractAddress string,
-	positions []types.HealthCheckWorkItem,
-) ([]UserResult, error) {
-	var userResults []UserResult
-	var batchEvents BatchEventsResponse
-	positonMap := make(map[string]types.HealthCheckWorkItem)
-
-	var queries []BatchQuery
-	for _, position := range positions {
-
-		// store addresses in this local map so that we can easily add debts and collateral later
-		positonMap[position.Address] = position
-		batchQuery := BatchQuery{
-			Query: fmt.Sprintf(`query($contractAddress: String! $userAddress: String!) {
-                        %s:wasm {
-							contractQuery(contractAddress: $contractAddress, query: { health : { account_id: $userAddress } })
-						}
-                    }`, position.Address),
-			Variables: map[string]interface{}{
-				"contractAddress": contractAddress,
-				"userAddress":     position.Address,
-			},
-		}
-		queries = append(queries, batchQuery)
-	}
-
-	queryBytes, err := json.Marshal(queries)
-	if err != nil {
-		fmt.Println(fmt.Errorf("An Error occurred fetching data: %v", err))
-		return userResults, err
-	}
-
-	response, err := http.Post(hive.HiveEndpoint, "application/json", bytes.NewReader(queryBytes))
-
-	if err != nil {
-		return userResults, err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != 200 {
-		return userResults, fmt.Errorf("not found %d", response.StatusCode)
-	}
-
-	err = json.NewDecoder(response.Body).Decode(&batchEvents)
-	if err != nil {
-		return userResults, err
-	}
-
-	for _, event := range batchEvents {
-		// event.Data is now the address[contractQuery] map
-
-		for address, data := range event.Data {
-			position := positonMap[address]
-			userResults = append(userResults, UserResult{
-				Address:       address,
-				ContractQuery: data.ContractQuery,
-				Debts:         position.Debts,
-				Collateral:    position.Collateral,
 			})
 		}
 	}

--- a/health-checker/src/health-checker/hive_test.go
+++ b/health-checker/src/health-checker/hive_test.go
@@ -15,9 +15,7 @@ func Test_weCanQueryMultipleUsers(t *testing.T) {
 	batchSize := 200
 
 	mockPosition := types.HealthCheckWorkItem{
-		Address:    "osmo18nm43hck80s2et26g2csvltecvhk49526dugd9",
-		Debts:      []types.Asset{},
-		Collateral: []types.Asset{},
+		Identifier: "osmo18nm43hck80s2et26g2csvltecvhk49526dugd9",
 	}
 
 	positions := []types.HealthCheckWorkItem{}

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -6,7 +6,7 @@
 
 IMAGE_NAME := "multichain-manager:latest"
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
-REDBANK_ADDRESS := "osmo1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsll0sqv"
+REDBANK_ADDRESS := "osmo1cljmlh9ctfv00ug9m3ndrsyyyfqlxnx4welnw8upgu6ylhd6hk4qchm9rt"
 AWS_ACCESS_KEY := "123456"
 AWS_ACCESS_KEY_SECRET := "abcd"
 HIVE_URL := "http://127.0.0.1:8080/graphql"
@@ -14,7 +14,7 @@ LCD_ENDPOINT := "http://127.0.0.1:1317"
 RPC_ENDPOINT := "http://127.0.0.1:26657"
 RPC_WEBSOCKET_ENDPOINT := "ws://127.0.0.1:26657/websocket"
 AWS_CLUSTER_ARN := "1245"
-CHAIN_ID := "liq_test"
+CHAIN_ID := "osmosis-1"
 # This makes the APP_NAME be the name of the current directory
 # Ex. in path /home/dev/app/my-app the APP_NAME will be set to my-app
 APP_NAME := $(notdir $(CURDIR))
@@ -46,6 +46,7 @@ run: build .start_redis ## Build and run the service binary
 	REDIS_DATABASE=0 \
 	REDIS_METRICS_DATABASE=0 \
 	REDIS_ENDPOINT="127.0.0.1:6379" \
+	WORK_ITEM_TYPE="Rover" \
 	COLLECTOR_QUEUE_NAME="collector" \
 	COLLECTOR_ITEMS_PER_PACKET=4000 \
 	HEALTH_CHECK_QUEUE_NAME="health_check" \

--- a/manager/src/manager/manager.go
+++ b/manager/src/manager/manager.go
@@ -37,6 +37,9 @@ type Manager struct {
 	collectorContract       string
 	collectorItemsPerPacket int
 
+	contractItemPrefix string
+	workItemType       types.WorkItemType
+
 	metricsEnabled bool
 
 	logger *logrus.Entry
@@ -65,6 +68,8 @@ func New(
 	scalers map[string]managerinterfaces.Scaler,
 	collectorContract string,
 	collectorItemsPerPacket int,
+	contractItemPrefix string,
+	workItemType types.WorkItemType,
 	metricsEnabled bool,
 	logger *logrus.Entry,
 ) (*Manager, error) {
@@ -93,6 +98,10 @@ func New(
 		return nil, errors.New("you must provide the contract to be monitored")
 	}
 
+	if workItemType != types.Redbank && workItemType != types.Rover {
+		return nil, errors.New("incorrect work item type provided: ")
+	}
+
 	return &Manager{
 		chainID:                 chainID,
 		rpcEndpoint:             rpcEndpoint,
@@ -107,6 +116,8 @@ func New(
 		scalers:                 scalers,
 		collectorContract:       collectorContract,
 		collectorItemsPerPacket: collectorItemsPerPacket,
+		contractItemPrefix:      contractItemPrefix,
+		workItemType:            workItemType,
 		logger:                  logger,
 		lastBlockTime:           time.Now(),
 		metricsEnabled:          metricsEnabled,
@@ -269,7 +280,8 @@ func (service *Manager) Run() error {
 				HiveEndpoint:       service.hiveEndpoint,
 				LCDEndpoint:        service.lcdEndpoint,
 				ContractAddress:    service.collectorContract,
-				ContractItemPrefix: "debts",
+				ContractItemPrefix: service.contractItemPrefix,
+				WorkItemType:       service.workItemType,
 				ContractPageOffset: offset,
 				ContractPageLimit:  uint64(limit),
 			}

--- a/runtime/types/healthcheck_work_item.go
+++ b/runtime/types/healthcheck_work_item.go
@@ -3,9 +3,7 @@ package types
 // HealthCheckWorkItem defines the parameters for the collector to send to the
 // health checker
 type HealthCheckWorkItem struct {
-	Address    string    `json:"address"`
-	Debts      []Asset   `json:"debts"`
-	Collateral []Asset   `json:"collateral"`
+	Identifier string    `json:"identifier"`
 	Endpoints  Endpoints `json:"endpoints"`
 }
 

--- a/runtime/types/work_item.go
+++ b/runtime/types/work_item.go
@@ -3,11 +3,19 @@ package types
 // WorkItem defines the parameters for the collector to use when querying
 // the contract state
 type WorkItem struct {
-	HiveEndpoint       string `json:"hive_endpoint"`
-	RPCEndpoint        string `json:"rpc_endpoint"`
-	LCDEndpoint        string `json:"lcd_endpoint"`
-	ContractAddress    string `json:"contract_address"`
-	ContractItemPrefix string `json:"contract_item_prefix"`
-	ContractPageOffset uint64 `json:"contract_page_offset"`
-	ContractPageLimit  uint64 `json:"contract_page_limit"`
+	HiveEndpoint       string       `json:"hive_endpoint"`
+	RPCEndpoint        string       `json:"rpc_endpoint"`
+	LCDEndpoint        string       `json:"lcd_endpoint"`
+	ContractAddress    string       `json:"contract_address"`
+	ContractItemPrefix string       `json:"contract_item_prefix"`
+	WorkItemType       WorkItemType `json:"work_item_type"`
+	ContractPageOffset uint64       `json:"contract_page_offset"`
+	ContractPageLimit  uint64       `json:"contract_page_limit"`
 }
+
+type WorkItemType string
+
+const (
+	Redbank WorkItemType = "Redbank"
+	Rover   WorkItemType = "Rover"
+)


### PR DESCRIPTION
This PR makes some changes to the collector and manager to allow creation of both rover and redbank services, and fetching the contract items from the raw contract storage. This can be done in a generalised way by specifying the workItemType ("Redbank" | "Rover") in the environment file.

This paves the way for us making the health checker more generic as well, and to enable deployment one one or both bots with a single configuration.

I have also removed some redundant code, such as the passing of debt and collaterals, as this is fetched by the liquidator.