### PR TITLE
Fix/rover run loop

### DIFF
--- a/liquidator/src/rover/config/osmosis.ts
+++ b/liquidator/src/rover/config/osmosis.ts
@@ -9,19 +9,20 @@ export const getConfig = (
 	if (network === Network.MAINNET) throw new Error('Mainnet network not yet supported')
 
 	return {
-		gasDenom: process.env.GAS_DENOM!,
+		gasDenom: 'uosmo',
 		hiveEndpoint: process.env.HIVE_ENDPOINT!,
 		lcdEndpoint: process.env.LCD_ENDPOINT!,
-		neutralAssetDenom: process.env.NEUTRAL_ASSET_DENOM!,
-		oracleAddress: process.env.ORACLE_ADDRESS!,
-		swapperAddress: process.env.SWAPPER_ADDRESS!,
-		redbankAddress: process.env.REDBANK_ADDRESS!,
-		accountNftAddress: process.env.ACCOUNT_NFT_ADDRESS!,
-		creditManagerAddress: process.env.CREDIT_MANAGER_ADDRESS!,
+		neutralAssetDenom: 'uosmo', // no usdc pools on testnet so we use osmo
+		swapperAddress: 'osmo1svc92mfvgfredd56ut83sy68vwzvd5nxu7844ljmlsrsxa8d8lssw7kd4x',
+		oracleAddress: 'osmo1dqz2u3c8rs5e7w5fnchsr2mpzzsxew69wtdy0aq4jsd76w7upmsstqe0s8',
+		redbankAddress: 'osmo1t0dl6r27phqetfu0geaxrng0u9zn8qgrdwztapt5xr32adtwptaq6vwg36',
+		accountNftAddress: 'osmo16wwckvccarltl4mlnjhw3lcj3v59yglhldgw36ldkknmjavqyaasgcessw',
+		creditManagerAddress: 'osmo1dzk4y3s9am6773sglhfc60nstz09c3gy978h2jka6wre5z4hlavq4pcwk0',
 		liquidatorMasterAddress: liquidatorMasterAddress,
 		liquidatorAddress: liquidatorAddress,
-		minGasTokens: Number(process.env.MIN_GAS_TOKENS!),
+		minGasTokens: 10000000,
 		logResults: false,
-		redisEndpoint: process.env.REDIS_ENDPOINT!,
+		redisEndpoint: process.env.REDIS_ENDPOINT || 'http://127:0.0.1:6379', // recommend using local
+		poolsRefreshWindow: 60000,
 	}
 }

--- a/liquidator/test/rover/integration/config.ts
+++ b/liquidator/test/rover/integration/config.ts
@@ -15,6 +15,7 @@ export interface TestConfig {
 	swapperAddress: string
 	rpcEndpoint: string
 	prefix: string
+	seedRedbankRequired: boolean
 	hiveEndpoint: string
 	lcdEndpoint: string
 	tests: {
@@ -50,6 +51,7 @@ export const testnetConfig: TestConfig = {
 	hiveEndpoint:
 		'https://osmosis-delphi-testnet-1.simply-vc.com.mt/XF32UOOU55CX/osmosis-hive/graphql',
 	lcdEndpoint: 'https://lcd-test.osmosis.zone',
+	seedRedbankRequired: false,
 
 	// configure what tests you want to run
 	tests: {
@@ -84,6 +86,7 @@ export const localnetConfig: TestConfig = {
 	prefix: 'osmo',
 	hiveEndpoint: 'http://127.0.0.1:8085/graphql',
 	lcdEndpoint: 'http://127.0.0.1:1317',
+	seedRedbankRequired: false,
 
 	// configure what tests you want to run
 	tests: {

--- a/liquidator/test/rover/integration/liquidationTest.ts
+++ b/liquidator/test/rover/integration/liquidationTest.ts
@@ -56,13 +56,12 @@ const runTests = async (testConfig: TestConfig) => {
 
 	console.log('Master account setup complete')
 
-	if (false) {
-		await seedRedbank(client, masterAddress, testConfig)
-	}
-
 	console.log({ masterAddress })
 
-	console.log('Seeded redbank')
+	if (testConfig.seedRedbankRequired) {
+		await seedRedbank(client, masterAddress, testConfig)
+		console.log('Seeded redbank')
+	}
 
 	const config: RoverExecutorConfig = {
 		redbankAddress: testConfig.redbankAddress,
@@ -79,6 +78,7 @@ const runTests = async (testConfig: TestConfig) => {
 		logResults: true,
 		neutralAssetDenom: testConfig.usdcDenom,
 		redisEndpoint: 'http://127.0.0.1:6379', // not required for integration tests
+		poolsRefreshWindow: 60000,
 	}
 
 	// Set up our liquidator


### PR DESCRIPTION
Fix a couple of issues with the rover main `run()` loop

- was not calling liquidate()
- no try / catch, so network errors would kill the process. 

Also added a QOL change to tests where we have seeding the redbank with initial deposits as a flag. Seeding the redbank is required when there is no liquidity.