### PR TITLE
Fix/account id redis store

### DIFF
--- a/health-checker-rover/src/health-checker-rover/health_checker_rover.go
+++ b/health-checker-rover/src/health-checker-rover/health_checker_rover.go
@@ -142,7 +142,7 @@ func (s *HealthCheckerRover) produceUnhealthyPositions(results []UserResult) [][
 		liquidatable := userResult.ContractQuery.Liquidatable
 		if liquidatable {
 
-			positionDecoded, decodeError := json.Marshal(userResult)
+			positionDecoded, decodeError := json.Marshal(userResult.AccountId)
 			if decodeError == nil {
 				unhealthyPositions = append(unhealthyPositions, positionDecoded)
 			} else {
@@ -272,15 +272,15 @@ func (s *HealthCheckerRover) RunWorkerPool(jobs []worker_pool.Job) ([]UserResult
 		select {
 		case r, ok := <-wp.Results():
 
-			if !ok {
-				fmt.Println(fmt.Errorf("An unknown error occurred fetching data."))
-				continue
-			}
-
 			if r.Err != nil {
 				s.logger.WithFields(logrus.Fields{
 					"error": r.Err,
 				}).Error("Unable to fetch data")
+				continue
+			}
+
+			if !ok {
+				s.logger.Error("An unknown error occurred fetching data")
 				continue
 			}
 

--- a/health-checker-rover/src/health-checker-rover/health_checker_rover_test.go
+++ b/health-checker-rover/src/health-checker-rover/health_checker_rover_test.go
@@ -1,7 +1,7 @@
 package health_checker_rover
 
 import (
-	"github.com/mars-protocol/multichain-liquidator-bot/runtime/types"
+	"encoding/json"
 	"testing"
 )
 
@@ -54,19 +54,22 @@ func TestWeCanGenerateAndRunJobs(t *testing.T) {
 	if len(userResults) != len(positions) {
 		t.Errorf("Incorrect number of batches, found %d but expected %d", len(userResults), len(positions))
 	}
+
 }
 
 func TestCanFilterUnhealthyPositions(t *testing.T) {
+
 	dataA :=
 		ContractQuery{Liquidatable: true}
 
 	dataB :=
 		ContractQuery{Liquidatable: false}
 
+	accountId := "1234"
 	// create fake positions
 	results := []UserResult{
 		{
-			AccountId:     "1",
+			AccountId:     accountId,
 			ContractQuery: dataA,
 		},
 		{
@@ -79,6 +82,17 @@ func TestCanFilterUnhealthyPositions(t *testing.T) {
 
 	unhealthy := service.produceUnhealthyPositions(results)
 
+	var accounts []string
+
+	for _, item := range unhealthy {
+		var account string
+		json.Unmarshal(item, &account)
+		accounts = append(accounts, account)
+	}
+
+	if accounts[0] != accountId {
+		t.Fatalf("expected first account to equal 1")
+	}
 	if len(unhealthy) != 1 {
 		t.Fatalf("Expected 1 unhealthy position, found %d", len(unhealthy))
 	}

--- a/health-checker-rover/src/health-checker-rover/health_checker_rover_test.go
+++ b/health-checker-rover/src/health-checker-rover/health_checker_rover_test.go
@@ -32,7 +32,7 @@ func initService() HealthCheckerRover {
 func TestWeCanGenerateAndRunJobs(t *testing.T) {
 	batchSize := 200
 	mockPosition := types.RoverHealthCheckWorkItem{
-		AccountId: "25",
+		Identifier: "25",
 	}
 
 	positions := []types.RoverHealthCheckWorkItem{}
@@ -58,21 +58,19 @@ func TestWeCanGenerateAndRunJobs(t *testing.T) {
 
 func TestCanFilterUnhealthyPositions(t *testing.T) {
 	dataA :=
-		ContractQuery{
-			Health: Health{Liquidatable: true}}
+		ContractQuery{Liquidatable: true}
 
 	dataB :=
-		ContractQuery{
-			Health: Health{Liquidatable: false}}
+		ContractQuery{Liquidatable: false}
 
 	// create fake positions
 	results := []UserResult{
 		{
-			Address:       "aaaaaa",
+			AccountId:     "1",
 			ContractQuery: dataA,
 		},
 		{
-			Address:       "bbbbbb",
+			AccountId:     "2",
 			ContractQuery: dataB,
 		},
 	}

--- a/health-checker-rover/src/health-checker-rover/hive_rover_test.go
+++ b/health-checker-rover/src/health-checker-rover/hive_rover_test.go
@@ -13,7 +13,7 @@ func Test_weCanQueryAccounts(t *testing.T) {
 	batchSize := 200
 
 	mockPosition := types.RoverHealthCheckWorkItem{
-		AccountId: "25",
+		Identifier: "25",
 	}
 
 	positions := []types.RoverHealthCheckWorkItem{}
@@ -36,6 +36,6 @@ func Test_weCanQueryAccounts(t *testing.T) {
 		t.Errorf("Length was incorrect. Expected %d but got %d", expectedLength, actualLength)
 	}
 
-	liquidatable := result[0].ContractQuery.Health.Liquidatable
+	liquidatable := result[0].ContractQuery.Liquidatable
 	fmt.Printf("liquidatable: %t", liquidatable)
 }

--- a/health-checker-rover/src/health-checker-rover/rover_hive.go
+++ b/health-checker-rover/src/health-checker-rover/rover_hive.go
@@ -25,6 +25,7 @@ type ContractQuery struct {
 type Wasm struct {
 	ContractQuery ContractQuery `json:"contractQuery"`
 }
+
 type Data struct {
 	Wasm Wasm `json:"wasm"`
 }
@@ -40,10 +41,8 @@ type UserPosition struct {
 }
 
 type UserResult struct {
-	Address       string
+	AccountId     string
 	ContractQuery ContractQuery
-	Debts         []types.Asset
-	Collateral    []types.Asset
 }
 
 // BatchEventsResponse defines the format for batch position responses
@@ -105,7 +104,7 @@ func (hive *RoverHive) FetchBatch(
 
 		for accountId, data := range event.Data {
 			userResults = append(userResults, UserResult{
-				Address:       accountId,
+				AccountId:     accountId,
 				ContractQuery: data.ContractQuery,
 			})
 		}


### PR DESCRIPTION
For liquidating on rover we only need accountIds. This was being stored as an object like `{ "address" : "n" }`. This PR changes that to simply store the value n.

This changes the redis array from 

```
[
    { "address" : "1"}
    { "address" : "2"}
    ....
]
```

To 

```
[
    "1",
    "2",
    ...
]
```